### PR TITLE
fixes NoSuchMethod exception for inject in run_robot

### DIFF
--- a/bin/run_robot
+++ b/bin/run_robot
@@ -30,7 +30,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../config/boot')
 class_name = LyberCore::Robot.step_to_classname robot
 
 # instantiate a Robot object using the name
-klazz = class_name.inject(Object) {|o,c| o.const_get c}
+klazz = class_name.split('::').inject(Object) {|o,c| o.const_get c}
 bot = klazz.new
 bot.check_queued_status = false  # skipping the queued workflow status check
 


### PR DESCRIPTION
for example:

```
bin/run_robot:34:in `<main>': undefined method `inject' for "Robots::DorRepo::GisAssembly::AuthorMetadata":String (NoMethodError)
```
